### PR TITLE
Remove the 'alt' attribute from date inputs

### DIFF
--- a/AddCustomerNotes.php
+++ b/AddCustomerNotes.php
@@ -213,10 +213,10 @@ if (!isset($_GET['delete'])) {
 	echo '<tr>
 			<td>' . _('Date')  . '</td>';
 	if (isset($_POST['NoteDate'])) {
-		echo '<td><input type="text" required name="NoteDate" class="date" alt="' .$_SESSION['DefaultDateFormat']. '" id="datepicker" value="'.ConvertSQLDate($_POST['NoteDate']).'" size="10" maxlength="10" /></td>
+		echo '<td><input type="text" required name="NoteDate" class="date" value="'.ConvertSQLDate($_POST['NoteDate']).'" size="11" maxlength="10" /></td>
 			</tr>';
 	} else {
-		echo '<td><input type="text" required name="NoteDate" class="date" alt="' .$_SESSION['DefaultDateFormat']. '" id="datepicker" size="10" maxlength="10" /></td>
+		echo '<td><input type="text" required name="NoteDate" class="date" size="11" maxlength="10" /></td>
 			</tr>';
 	}
 	echo '<tr>

--- a/AddCustomerTypeNotes.php
+++ b/AddCustomerTypeNotes.php
@@ -201,7 +201,7 @@ if (!isset($_GET['delete'])) {
 		</tr>
 		<tr>
 			<td>' .  _('Date').':</td>
-			<td><input type="text" required="required" name="NoteDate" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" value="'. $_POST['NoteDate']. '" size="10" maxlength="10" /></td>
+			<td><input type="text" required="required" name="NoteDate" class="date" value="'. $_POST['NoteDate']. '" size="11" maxlength="10" /></td>
 		</tr>
 		<tr>
 			<td>' .  _('Priority').':</td>

--- a/AuditTrail.php
+++ b/AuditTrail.php
@@ -40,11 +40,11 @@ echo '<table class="selection">';
 
 echo '<tr>
 		<td>' .  _('From Date') . ' ' . $_SESSION['DefaultDateFormat']  . '</td>
-		<td><input tabindex="1" type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="FromDate" size="11" maxlength="10" autofocus="autofocus" required="required" value="' .$_POST['FromDate']. '" onchange="isDate(this, this.value, '."'".$_SESSION['DefaultDateFormat']."'".')"/></td>
+		<td><input tabindex="1" type="text" class="date" name="FromDate" size="11" maxlength="10" autofocus="autofocus" required="required" value="' .$_POST['FromDate']. '" onchange="isDate(this, this.value, '."'".$_SESSION['DefaultDateFormat']."'".')"/></td>
 	</tr>
 	<tr>
 		<td>' .  _('To Date') . ' ' . $_SESSION['DefaultDateFormat']  . '</td>
-		<td><input tabindex="2" type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="ToDate" size="11" maxlength="10" required="required" value="' . $_POST['ToDate'] . '" onchange="isDate(this, this.value, '."'".$_SESSION['DefaultDateFormat']."'".')"/></td>
+		<td><input tabindex="2" type="text" class="date" name="ToDate" size="11" maxlength="10" required="required" value="' . $_POST['ToDate'] . '" onchange="isDate(this, this.value, '."'".$_SESSION['DefaultDateFormat']."'".')"/></td>
 	</tr>';
 
 // Show user selections

--- a/BOMs.php
+++ b/BOMs.php
@@ -463,7 +463,7 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 							WHERE parent='" . $SelectedParent ."'";
 		$ComponentResult = DB_query($ComponentSQL);
 		$ComponentArray = DB_fetch_row($ComponentResult);
-		
+
 		if ($_SESSION['WeightedAverageCosting'] != 1) {//only update the cost for standard cost
 			UpdateCost($ComponentArray[0]);
 		}
@@ -875,11 +875,11 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 
 		echo '<tr>
 				<td>' . _('Effective After') . ' (' . $_SESSION['DefaultDateFormat'] . '):</td>
-				<td><input ' . (in_array('EffectiveAfter',$Errors) ?  'class="inputerror"' : '' ) . ' tabindex="5" type="text" required="required" name="EffectiveAfter" class="date" alt="' .$_SESSION['DefaultDateFormat'] .'" size="11" maxlength="10" value="' . $_POST['EffectiveAfter'] .'" /></td>
+				<td><input ' . (in_array('EffectiveAfter',$Errors) ?  'class="inputerror"' : '' ) . ' tabindex="5" type="text" required="required" name="EffectiveAfter" class="date" size="11" maxlength="10" value="' . $_POST['EffectiveAfter'] .'" /></td>
 			</tr>
 			<tr>
 				<td>' . _('Effective To') . ' (' . $_SESSION['DefaultDateFormat'] . '):</td>
-				<td><input  ' . (in_array('EffectiveTo',$Errors) ?  'class="inputerror"' : '' ) . ' tabindex="6" type="text" name="EffectiveTo" class="date" alt="' .$_SESSION['DefaultDateFormat'] . '" size="11" maxlength="10" value="' . $_POST['EffectiveTo'] .'" /></td>
+				<td><input  ' . (in_array('EffectiveTo',$Errors) ?  'class="inputerror"' : '' ) . ' tabindex="6" type="text" name="EffectiveTo" class="date" size="11" maxlength="10" value="' . $_POST['EffectiveTo'] .'" /></td>
 			</tr>';
 
 		if ($ParentMBflag=='M' OR $ParentMBflag=='G'){

--- a/BOMs_SingleLevel.php
+++ b/BOMs_SingleLevel.php
@@ -765,11 +765,11 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 
 		echo '<tr>
 				<td>' . _('Effective After') . ' (' . $_SESSION['DefaultDateFormat'] . '):</td>
-				<td><input ' . (in_array('EffectiveAfter',$Errors) ?  'class="inputerror"' : '' ) . ' tabindex="5" type="text" required="required" name="EffectiveAfter" class="date" alt="' .$_SESSION['DefaultDateFormat'] .'" size="11" maxlength="10" value="' . $_POST['EffectiveAfter'] .'" /></td>
+				<td><input ' . (in_array('EffectiveAfter',$Errors) ?  'class="inputerror"' : '' ) . ' tabindex="5" type="text" required="required" name="EffectiveAfter" class="date" size="11" maxlength="10" value="' . $_POST['EffectiveAfter'] .'" /></td>
 			</tr>
 			<tr>
 				<td>' . _('Effective To') . ' (' . $_SESSION['DefaultDateFormat'] . '):</td>
-				<td><input  ' . (in_array('EffectiveTo',$Errors) ?  'class="inputerror"' : '' ) . ' tabindex="6" type="text" name="EffectiveTo" class="date" alt="' .$_SESSION['DefaultDateFormat'] . '" size="11" maxlength="10" value="' . $_POST['EffectiveTo'] .'" /></td>
+				<td><input  ' . (in_array('EffectiveTo',$Errors) ?  'class="inputerror"' : '' ) . ' tabindex="6" type="text" name="EffectiveTo" class="date" size="11" maxlength="10" value="' . $_POST['EffectiveTo'] .'" /></td>
 			</tr>';
 
 		if ($ParentMBflag=='M' OR $ParentMBflag=='G'){

--- a/ConfirmDispatch_Invoice.php
+++ b/ConfirmDispatch_Invoice.php
@@ -1781,7 +1781,7 @@ invoices can have a zero amount but there must be a quantity to invoice */
 	echo '<table class="selection">
 		<tr>
 			<td>' ._('Date On Invoice'). ':</td>
-			<td><input tabindex="'.$j.'" type="text" required="required" maxlength="10" size="15" required="required" name="DispatchDate" value="' . $DefaultDispatchDate . '" id="datepicker" alt="' . $_SESSION['DefaultDateFormat'] . '" class="date" /></td>
+			<td><input tabindex="'.$j.'" type="text" required="required" maxlength="10" size="11" required="required" name="DispatchDate" value="' . $DefaultDispatchDate . '" class="date" /></td>
 		</tr>';
 	$j++;
 	echo '<tr>

--- a/Contracts.php
+++ b/Contracts.php
@@ -930,7 +930,7 @@ if (!isset($_SESSION['Contract'.$identifier]->DebtorNo)
 
 	echo '<tr>
 			<td>' . _('Required Date') . ':</td>
-			<td><input type="text" required="required" class="date" alt="' .$_SESSION['DefaultDateFormat'] . '" name="RequiredDate" size="11" value="' . $_SESSION['Contract'.$identifier]->RequiredDate . '" /></td>
+			<td><input type="text" required="required" class="date" name="RequiredDate" maxlength="10" size="11" value="' . $_SESSION['Contract'.$identifier]->RequiredDate . '" /></td>
 		</tr>';
 
 	echo '<tr>

--- a/CustomerAccount.php
+++ b/CustomerAccount.php
@@ -237,7 +237,7 @@ if ($CustomerRecord['dissallowinvoices'] != 0) {
 }
 echo '<br /><form onSubmit="return VerifyForm(this);" action="', htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES, 'UTF-8'), '" method="post" class="centre noprint">
 		<input name="FormID" type="hidden" value="', $_SESSION['FormID'], '" />',
-		_('Show all transactions after'), ':<input alt="', $_SESSION['DefaultDateFormat'], '" class="date" id="datepicker" maxlength="10" minlength="0" name="TransAfterDate" required="required" size="12" tabindex="1" type="text" value="', $_POST['TransAfterDate'], '" />',
+		_('Show all transactions after'), ':<input class="date" maxlength="10" name="TransAfterDate" required="required" size="11" tabindex="1" type="text" value="', $_POST['TransAfterDate'], '" />',
 		'<input name="Refresh Inquiry" tabindex="3" type="submit" value="', _('Refresh Inquiry'), '" />
 	</form>';
 

--- a/CustomerInquiry.php
+++ b/CustomerInquiry.php
@@ -185,7 +185,7 @@ echo '<tr>
 
 echo '<div class="centre"><form onSubmit="return VerifyForm(this);" action="', htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES, 'UTF-8'), '" method="post" class="noPrint">
 		<input type="hidden" name="FormID" value="', $_SESSION['FormID'], '" />';
-echo _('Show all transactions after'), ':<input type="text" required="required" class="date" alt="', $_SESSION['DefaultDateFormat'], '" id="datepicker" name="TransAfterDate" value="', $_POST['TransAfterDate'], '" minlength="0" maxlength="10" size="12" />';
+echo _('Show all transactions after'), ':<input type="text" required="required" class="date" name="TransAfterDate" value="', $_POST['TransAfterDate'], '" maxlength="10" size="11" />';
 
 echo '<select name="Status">';
 if ($_POST['Status'] == '') {

--- a/CustomerReceipt.php
+++ b/CustomerReceipt.php
@@ -851,7 +851,7 @@ if (!Is_Date($_SESSION['ReceiptBatch' . $identifier]->DateBanked)){
 
 echo '<tr>
 		<td>' . _('Date Banked') . ':</td>
-		<td><input tabindex="2" type="text" required="required" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="DateBanked" maxlength="10" size="10" onchange="isDate(this, this.value, '."'".$_SESSION['DefaultDateFormat']."'".')" value="' . $_SESSION['ReceiptBatch' . $identifier]->DateBanked . '" /></td>
+		<td><input tabindex="2" type="text" required="required" class="date" name="DateBanked" maxlength="10" size="11" onchange="isDate(this, this.value, '."'".$_SESSION['DefaultDateFormat']."'".')" value="' . $_SESSION['ReceiptBatch' . $identifier]->DateBanked . '" /></td>
 	</tr>
 	<tr>
 		<td>' . _('Currency') . ':</td>

--- a/CustomerTransInquiry.php
+++ b/CustomerTransInquiry.php
@@ -47,9 +47,9 @@ if (!isset($_POST['ToDate'])){
 	$_POST['ToDate'] = Date($_SESSION['DefaultDateFormat']);
 }
 echo '<td>' . _('From') . ':</td>
-	<td><input alt="'.$_SESSION['DefaultDateFormat'].'" class="date" maxlength="10" name="FromDate" required="required" size="11" tabindex="2" type="text" value="' . $_POST['FromDate'] . '" /></td>
+	<td><input class="date" maxlength="10" name="FromDate" required="required" size="11" tabindex="2" type="text" value="' . $_POST['FromDate'] . '" /></td>
 	<td>' . _('To') . ':</td>
-	<td><input alt="'.$_SESSION['DefaultDateFormat'].'" class="date" maxlength="10" name="ToDate" required="required" size="11" tabindex="3" type="text" value="' . $_POST['ToDate'] . '" /></td>
+	<td><input class="date" maxlength="10" name="ToDate" required="required" size="11" tabindex="3" type="text" value="' . $_POST['ToDate'] . '" /></td>
 	</tr>
 	</table>
 	<br />

--- a/Customers.php
+++ b/Customers.php
@@ -544,7 +544,7 @@ if (!isset($DebtorNo)) {
 	$DateString = Date($_SESSION['DefaultDateFormat']);
 	echo '<tr>
 			<td>' . _('Customer Since') . ' (' . $_SESSION['DefaultDateFormat'] . '):</td>
-			<td><input tabindex="10" type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="ClientSince" value="' . $DateString . '" size="12" maxlength="10" /></td>
+			<td><input tabindex="10" type="text" class="date" name="ClientSince" value="' . $DateString . '" size="11" maxlength="10" /></td>
 		</tr>';
 
 	echo '</table></td>
@@ -915,7 +915,7 @@ if (!isset($DebtorNo)) {
 			</tr>
 			<tr>
 				<td>' . _('Customer Since') . ' (' . $_SESSION['DefaultDateFormat'] . '):</td>
-				<td><input ' . (in_array('ClientSince',$Errors) ?  'class="inputerror"' : '' ) .' type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="ClientSince" size="11" maxlength="10" value="' . $_POST['ClientSince'] . '" /></td>
+				<td><input ' . (in_array('ClientSince',$Errors) ?  'class="inputerror"' : '' ) .' type="text" class="date" name="ClientSince" size="11" maxlength="10" value="' . $_POST['ClientSince'] . '" /></td>
 			</tr>
 			</table></td>
 			<td><table class="selection">';

--- a/DailyBankTransactions.php
+++ b/DailyBankTransactions.php
@@ -58,12 +58,12 @@ if (!isset($_POST['Show'])) {
 	}
 	echo '<tr>
 			<td>' . _('Transactions Dated From') . ':</td>
-			<td><input type="text" name="FromTransDate" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" required="required" maxlength="10" size="11" onchange="isDate(this, this.value, '."'".$_SESSION['DefaultDateFormat']."'".')" value="' .
+			<td><input type="text" name="FromTransDate" class="date" required="required" maxlength="10" size="11" onchange="isDate(this, this.value, '."'".$_SESSION['DefaultDateFormat']."'".')" value="' .
 				date($_SESSION['DefaultDateFormat']) . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('Transactions Dated To') . ':</td>
-			<td><input type="text" name="ToTransDate" class="date" alt="'.$_SESSION['DefaultDateFormat'].'"  required="required" maxlength="10" size="11" onchange="isDate(this, this.value, '."'".$_SESSION['DefaultDateFormat']."'".')" value="' . date($_SESSION['DefaultDateFormat']) . '" /></td>
+			<td><input type="text" name="ToTransDate" class="date" required="required" maxlength="10" size="11" onchange="isDate(this, this.value, '."'".$_SESSION['DefaultDateFormat']."'".')" value="' . date($_SESSION['DefaultDateFormat']) . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('Show Transactions') . '</td>

--- a/DeliveryDetails.php
+++ b/DeliveryDetails.php
@@ -1029,17 +1029,17 @@ if(!isset($_SESSION['Items'.$identifier]->ConfirmedDate)) {
 // The estimated Dispatch date or Delivery date for this order
 echo '<tr>
 		<td>' .  _('Estimated Delivery Date') .':</td>
-		<td><input class="date" alt="'.$_SESSION['DefaultDateFormat'].'" type="text" size="15" maxlength="14" name="DeliveryDate" value="' . $_SESSION['Items'.$identifier]->DeliveryDate . '" title="' . _('Enter the estimated delivery date requested by the customer') . '"/></td>
+		<td><input class="date" type="text" size="11" maxlength="10" name="DeliveryDate" value="' . $_SESSION['Items'.$identifier]->DeliveryDate . '" title="' . _('Enter the estimated delivery date requested by the customer') . '"/></td>
 	</tr>';
 // The date when a quote was issued to the customer
 echo '<tr>
 		<td>' .  _('Quote Date') .':</td>
-		<td><input class="date" alt="'.$_SESSION['DefaultDateFormat'].'" type="text" size="15" maxlength="14" name="QuoteDate" value="' . $_SESSION['Items'.$identifier]->QuoteDate . '" /></td>
+		<td><input class="date" type="text" size="11" maxlength="10" name="QuoteDate" value="' . $_SESSION['Items'.$identifier]->QuoteDate . '" /></td>
 	</tr>';
 // The date when the customer confirmed their order
 echo '<tr>
 		<td>' .  _('Confirmed Order Date') .':</td>
-		<td><input class="date" alt="'.$_SESSION['DefaultDateFormat'].'" type="text" size="15" maxlength="14" name="ConfirmedDate" value="' . $_SESSION['Items'.$identifier]->ConfirmedDate . '" /></td>
+		<td><input class="date" type="text" size="11" maxlength="10" name="ConfirmedDate" value="' . $_SESSION['Items'.$identifier]->ConfirmedDate . '" /></td>
 	</tr>
 	<tr>
 		<td>' .  _('Delivery Address 1 (Street)') . ':</td>

--- a/FixedAssetDepreciation.php
+++ b/FixedAssetDepreciation.php
@@ -274,7 +274,7 @@ if (isset($_POST['CommitDepreciation']) AND $InputError==false){
 		<tr>';
 	if ($AllowUserEnteredProcessDate){
 		echo '<td>' . _('Date to Process Depreciation'). ':</td>
-			<td><input type="text" class="date" alt="' .$_SESSION['DefaultDateFormat']. '" required="required" name="ProcessDate" maxlength="10" size="11" value="' . $_POST['ProcessDate'] . '" /></td>';
+			<td><input type="text" class="date" required="required" name="ProcessDate" maxlength="10" size="11" value="' . $_POST['ProcessDate'] . '" /></td>';
 	} else {
 		echo '<td>' . _('Date to Process Depreciation'). ':</td>
 			<td>' . $_POST['ProcessDate']  . '</td>';

--- a/FixedAssetRegister.php
+++ b/FixedAssetRegister.php
@@ -312,11 +312,11 @@ if (isset($_POST['submit']) OR isset($_POST['pdf']) OR isset($_POST['csv'])) {
 
 	echo '<tr>
 			<th>' . _(' From Date') . '</th>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="FromDate" required="required" title="' . _('Enter the start date to show the cost and accumulated depreciation from') . '" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
+			<td><input type="text" class="date" name="FromDate" required="required" title="' . _('Enter the start date to show the cost and accumulated depreciation from') . '" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
 		</tr>
 		<tr>
 			<th>' . _('To Date ') . '</th>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" required="required" title="' . _('Enter the end date to show the cost and accumulated depreciation to') . '" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
+			<td><input type="text" class="date" name="ToDate" required="required" title="' . _('Enter the end date to show the cost and accumulated depreciation to') . '" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
 		</tr>
 	</table>
 	<br />

--- a/GLJournal.php
+++ b/GLJournal.php
@@ -261,7 +261,7 @@ echo '<table>
         <td colspan="5"><table class="selection">
 						<tr>
 							<td>' . _('Date to Process Journal') . ':</td>
-							<td><input type="text" required="required" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="JournalProcessDate" maxlength="10" size="11" value="' . $_SESSION['JournalDetail']->JnlDate . '" /></td>
+							<td><input type="text" required="required" class="date" name="JournalProcessDate" maxlength="10" size="11" value="' . $_SESSION['JournalDetail']->JnlDate . '" /></td>
 							<td>' . _('Type') . ':</td>
 							<td><select name="JournalType">';
 

--- a/GLJournalInquiry.php
+++ b/GLJournalInquiry.php
@@ -58,8 +58,8 @@ if (!isset($_POST['Show'])) {
 	}
 
 	echo '<tr><td>' . _('Journals Dated Between') . ':</td>
-		<td>' . _('From') . ':'. '<input type="text" name="FromTransDate" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" maxlength="10" size="11" value="' . ConvertSQLDate($FromDate) . '" /></td>
-		<td>' . _('To') . ':'. '<input type="text" name="ToTransDate" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" maxlength="10" size="11" value="' . ConvertSQLDate($ToDate) . '" /></td>
+		<td>' . _('From') . ':'. '<input type="text" name="FromTransDate" class="date" maxlength="10" size="11" value="' . ConvertSQLDate($FromDate) . '" /></td>
+		<td>' . _('To') . ':'. '<input type="text" name="ToTransDate" class="date" maxlength="10" size="11" value="' . ConvertSQLDate($ToDate) . '" /></td>
 		</tr>';
 
 	echo '</table>';

--- a/GoodsReceived.php
+++ b/GoodsReceived.php
@@ -101,7 +101,7 @@ if (!isset($_POST['ProcessGoodsReceived'])) {
 	echo '<table class="selection">
 			<tr>
 				<td>' .  _('Date Goods/Service Received'). ':</td>
-				<td><input type="text" class="date" alt="'. $_SESSION['DefaultDateFormat'] .'" maxlength="10" size="10" onchange="return isDate(this, this.value, '."'".
+				<td><input type="text" class="date" maxlength="10" size="11" onchange="return isDate(this, this.value, '."'".
 			$_SESSION['DefaultDateFormat']."'".')" name="DefaultReceivedDate" value="' . $_SESSION['PO' . $identifier]->DefaultReceivedDate . '" /></td>
 				<td>' . _("Supplier's Reference") . ':</td>
 				<td><input type="text" name="SupplierReference" value="' . $SupplierReference. '" maxlength="30" size="20"  onchange="ReloadForm(form1.Update)"/></td>

--- a/HistoricalTestResults.php
+++ b/HistoricalTestResults.php
@@ -69,11 +69,11 @@ echo '</select></td>';
 echo '</tr>
 	  <tr>
 		<td>' . _('From Sample Date') . ': </td>
-		<td><input name="FromDate" size="10" class="date" value="' . $_POST['FromDate'] . '" alt="' . $_SESSION['DefaultDateFormat'] . '" /></td>
+		<td><input name="FromDate" maxlength="10" size="11" class="date" value="' . $_POST['FromDate'] . '" /></td>
 	</tr>
 	<tr>
 		<td> ' . _('To Sample Date') . ':</td>
-		<td> <input name="ToDate" size="10" class="date" value="' . $_POST['ToDate'] . '" alt="' . $_SESSION['DefaultDateFormat'] . '" /></td>
+		<td> <input name="ToDate" maxlength="10" size="11" class="date" value="' . $_POST['ToDate'] . '" /></td>
 	</tr>
 	</table>
 	</div>

--- a/MRPCalendar.php
+++ b/MRPCalendar.php
@@ -261,9 +261,9 @@ function ShowInputForm(&$ChangeDate)  {//####DISPLAY_DISPLAY_DISPLAY_DISPLAY_DIS
 
 	echo '<tr>
 			<td>' . _('From Date') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] .'" name="FromDate" required="required" autofocus="autofocus" size="10" maxlength="10" value="' . $_POST['FromDate'] . '" /></td></tr>
+			<td><input type="text" class="date" name="FromDate" required="required" autofocus="autofocus" size="11" maxlength="10" value="' . $_POST['FromDate'] . '" /></td></tr>
 			<tr><td>' . _('To Date') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] .'" name="ToDate" required="required" size="10" maxlength="10" value="' . $_POST['ToDate'] . '" /></td>
+			<td><input type="text" class="date" name="ToDate" required="required" size="11" maxlength="10" value="' . $_POST['ToDate'] . '" /></td>
 		</tr>
 		<tr><td></td></tr>
 		<tr><td></td></tr>
@@ -310,7 +310,7 @@ function ShowInputForm(&$ChangeDate)  {//####DISPLAY_DISPLAY_DISPLAY_DISPLAY_DIS
 		<table class="selection">
 		<tr>
 			<td>' . _('Change Date Status') . ':</td>
-			<td><input type="text" name="ChangeDate" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" size="12" maxlength="12" value="' . $_POST['ChangeDate'] . '" /></td>
+			<td><input type="text" name="ChangeDate" class="date" size="11" maxlength="10" value="' . $_POST['ChangeDate'] . '" /></td>
 			<td><input type="submit" name="update" value="' . _('Update') . '" /></td>
 		</tr>
 		</table>

--- a/MRPCreateDemands.php
+++ b/MRPCreateDemands.php
@@ -246,11 +246,11 @@ if (!isset($_POST['DistDate'])) {
 }
 echo '<tr>
 		<td>' . _('From Sales Date') . ':</td>
-		<td><input type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="FromDate" size="10" value="' . $_POST['FromDate'] . '" />&nbsp;&nbsp;&nbsp;'. _('To Sales Date') . ':<input type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="ToDate" size="10" value="' . $_POST['ToDate'] . '" /></td>
+		<td><input type="text" class="date" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" />&nbsp;&nbsp;&nbsp;'. _('To Sales Date') . ':<input type="text" class="date" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
 	</tr>
 	<tr>
 		<td>' . _('Start Date For Distribution') . ':</td>
-		<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] .'" name="DistDate" size="10" value="' . $_POST['DistDate'] . '" /></td>
+		<td><input type="text" class="date" name="DistDate" maxlength="10" size="11" value="' . $_POST['DistDate'] . '" /></td>
 	</tr>
 	<tr>
 		<td>' . _('Distribution Period') . ':</td>

--- a/MRPDemands.php
+++ b/MRPDemands.php
@@ -389,7 +389,7 @@ function display(&$StockID,&$DemandID) { //####DISPLAY_DISPLAY_DISPLAY_DISPLAY_D
 			</tr>
 			<tr>
 				<td>' . _('Due Date') . ':</td>
-				<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="Duedate" size="12" maxlength="12" value="' . $_POST['Duedate'] . '" /></td>
+				<td><input type="text" class="date" name="Duedate" size="11" maxlength="10" value="' . $_POST['Duedate'] . '" /></td>
 			</tr>';
 		// Generate selections for Demand Type
 		echo '<tr>

--- a/MRPPlannedPurchaseOrders.php
+++ b/MRPPlannedPurchaseOrders.php
@@ -369,7 +369,7 @@ if ( isset($_POST['PrintPDF']) OR isset($_POST['Review']) ) {
 			<tr>
 				<td>' . _('Cut Off Date') . ':</td>
 				<td>
-					<input type ="text" required="required" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="cutoffdate" autofocus="autofocus" size="10" value="' . date($_SESSION['DefaultDateFormat']) . '" />
+					<input type="text" required="required" class="date" name="cutoffdate" autofocus="autofocus" maxlength="10" size="11" value="' . date($_SESSION['DefaultDateFormat']) . '" />
 				</td>
 			</tr>
 			</table>

--- a/MRPPlannedWorkOrders.php
+++ b/MRPPlannedWorkOrders.php
@@ -335,7 +335,7 @@ if ( isset($_POST['PrintPDF']) OR isset($_POST['Review']) ) {
              <tr>
                  <td>' . _('Cut Off Date') . ':</td>
 				<td>
-					<input type ="text" required="required" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="cutoffdate" autofocus="autofocus" size="10" value="' . date($_SESSION['DefaultDateFormat']) . '" />
+					<input type="text" required="required" class="date" name="cutoffdate" autofocus="autofocus" maxlength="10" size="11" value="' . date($_SESSION['DefaultDateFormat']) . '" />
 				</td>
 	     </tr>
              </table>

--- a/PDFChequeListing.php
+++ b/PDFChequeListing.php
@@ -37,10 +37,10 @@ if (!isset($_POST['FromDate']) OR !isset($_POST['ToDate'])){
 	echo '<table class="selection">
 	 		<tr>
 				<td>' . _('Enter the date from which cheques are to be listed') . ':</td>
-				<td><input type="text" name="FromDate" maxlength="10" size="10" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '"  value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
+				<td><input type="text" name="FromDate" maxlength="10" size="11" class="date" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
 			</tr>';
 	 echo '<tr><td>' . _('Enter the date to which cheques are to be listed') . ':</td>
-	 		<td><input type="text" name="ToDate" maxlength="10" size="10"  class="date" alt="' . $_SESSION['DefaultDateFormat'] . '"  value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
+	 		<td><input type="text" name="ToDate" maxlength="10" size="11"  class="date" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
 	</tr>';
 	 echo '<tr><td>' . _('Bank Account') . '</td><td>';
 

--- a/PDFCustTransListing.php
+++ b/PDFCustTransListing.php
@@ -34,7 +34,7 @@ if (!isset($_POST['Date'])){
 	 echo '<table class="selection">
 	 		<tr>
 				<td>' . _('Enter the date for which the transactions are to be listed') . ':</td>
-				<td><input type="text" name="Date" maxlength="10" size="10" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
+				<td><input type="text" name="Date" maxlength="10" size="11" class="date" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
 			</tr>';
 
 	echo '<tr><td>' . _('Transaction type') . '</td>

--- a/PDFCustomerList.php
+++ b/PDFCustomerList.php
@@ -411,7 +411,7 @@ if(isset($_POST['PrintPDF'])) {
 	$DefaultActivitySince = Date($_SESSION['DefaultDateFormat'], Mktime(0,0,0,Date('m')-6,0,Date('y')));
 	echo '<tr>
 			<td>' . _('Activity Since'). ':</td>
-			<td><input type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'"  name="ActivitySince" size="10" maxlength="10" value="' . $DefaultActivitySince . '" /></td>
+			<td><input type="text" class="date" name="ActivitySince" size="11" maxlength="10" value="' . $DefaultActivitySince . '" /></td>
 		</tr>';
 
 	echo '</table>

--- a/PDFDIFOT.php
+++ b/PDFDIFOT.php
@@ -29,11 +29,11 @@ if (!isset($_POST['FromDate']) OR !isset($_POST['ToDate']) OR $InputError==1){
 	 echo '<table class="selection">
 			<tr>
 				<td>' . _('Enter the date from which variances between orders and deliveries are to be listed') . ':</td>
-				<td><input type="text" required="required" autofocus="autofocus" class="date" alt="' .$_SESSION['DefaultDateFormat'].'" name="FromDate" maxlength="10" size="10" value="' . Date($_SESSION['DefaultDateFormat'], Mktime(0,0,0,Date('m')-1,0,Date('y'))) . '" /></td>
+				<td><input type="text" required="required" autofocus="autofocus" class="date" name="FromDate" maxlength="10" size="11" value="' . Date($_SESSION['DefaultDateFormat'], Mktime(0,0,0,Date('m')-1,0,Date('y'))) . '" /></td>
 			</tr>
 			<tr>
 				<td>' . _('Enter the date to which variances between orders and deliveries are to be listed') . ':</td>
-				<td><input type="text" required="required" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="ToDate" maxlength="10" size="10" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
+				<td><input type="text" required="required" class="date" name="ToDate" maxlength="10" size="11" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
 			</tr>';
 
 	 if (!isset($_POST['DaysAcceptable'])){

--- a/PDFDeliveryDifferences.php
+++ b/PDFDeliveryDifferences.php
@@ -29,11 +29,11 @@ if (!isset($_POST['FromDate']) OR !isset($_POST['ToDate']) OR $InputError==1){
 	echo '<table class="selection">
 			<tr>
 			<td>' . _('Enter the date from which variances between orders and deliveries are to be listed') . ':</td>
-			<td><input type="text" required="required" autofocus="autofocus" class="date" alt="' . $_SESSION['DefaultDateFormat']. '" name="FromDate" maxlength="10" size="10" value="' . Date($_SESSION['DefaultDateFormat'], Mktime(0,0,0,Date('m')-1,0,Date('y'))) . '" /></td>
+			<td><input type="text" required="required" autofocus="autofocus" class="date" name="FromDate" maxlength="10" size="11" value="' . Date($_SESSION['DefaultDateFormat'], Mktime(0,0,0,Date('m')-1,0,Date('y'))) . '" /></td>
 			</tr>';
 	echo '<tr>
 			<td>' . _('Enter the date to which variances between orders and deliveries are to be listed') . ':</td>
-			<td><input type="text" required="required" class="date" alt="' . $_SESSION['DefaultDateFormat']. '"  name="ToDate" maxlength="10" size="10" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
+			<td><input type="text" required="required" class="date" name="ToDate" maxlength="10" size="11" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
 			</tr>';
 	echo '<tr>
 			<td>' . _('Inventory Category') . '</td>

--- a/PDFLowGP.php
+++ b/PDFLowGP.php
@@ -129,11 +129,11 @@ if (isset($_POST['PrintPDF'])) {
 		echo '<table class="selection">';
 		echo '<tr>
 				<td>' . _('Sales Made From') . ' (' . _('in the format') . ' ' . $_SESSION['DefaultDateFormat'] . '):</td>
-				<td><input type="text" required="required" autofocus="autofocus" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="FromDate" size="10" maxlength="10" value="' . $_POST['FromDate'] . '" /></td>
+				<td><input type="text" required="required" autofocus="autofocus" class="date" name="FromDate" size="11" maxlength="10" value="' . $_POST['FromDate'] . '" /></td>
 			</tr>
 			<tr>
 				<td>' . _('Sales Made To') . ' (' . _('in the format') . ' ' . $_SESSION['DefaultDateFormat'] . '):</td>
-				<td><input type="text" required="required" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" size="10" maxlength="10" value="' . $_POST['ToDate'] . '" /></td>
+				<td><input type="text" required="required" class="date" name="ToDate" size="11" maxlength="10" value="' . $_POST['ToDate'] . '" /></td>
 			</tr>
 			<tr>
 				<td>' . _('Show sales with GP % below') . ':</td>

--- a/PDFOrderStatus.php
+++ b/PDFOrderStatus.php
@@ -34,11 +34,11 @@ if (!isset($_POST['FromDate']) OR !isset($_POST['ToDate'])){
 		<table class="selection">
 		<tr>
 			<td>' . _('Enter the date from which orders are to be listed') . ':</td>
-			<td><input type="text" required="required" autofocus="autofocus" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="FromDate" maxlength="10" size="10" value="' . Date($_SESSION['DefaultDateFormat'], Mktime(0,0,0,Date('m'),Date('d')-1,Date('y'))) . '" /></td>
+			<td><input type="text" required="required" autofocus="autofocus" class="date" name="FromDate" maxlength="10" size="11" value="' . Date($_SESSION['DefaultDateFormat'], Mktime(0,0,0,Date('m'),Date('d')-1,Date('y'))) . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('Enter the date to which orders are to be listed') . ':</td>
-			<td><input type="text" required="required" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" maxlength="10" size="10" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
+			<td><input type="text" required="required" class="date" name="ToDate" maxlength="10" size="11" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('Inventory Category') . '</td>

--- a/PDFOrdersInvoiced.php
+++ b/PDFOrdersInvoiced.php
@@ -38,11 +38,11 @@ if (!isset($_POST['FromDate']) OR !isset($_POST['ToDate']) OR $InputError==1){
 		<table class="selection">
 		<tr>
 			<td>' . _('Enter the date from which orders are to be listed') . ':</td>
-			<td><input type="text" required="required" autofocus="autofocus" class="date" alt="' .$_SESSION['DefaultDateFormat'] .'" name="FromDate" maxlength="10" size="10" value="' . Date($_SESSION['DefaultDateFormat'], Mktime(0,0,0,Date('m'),Date('d')-1,Date('y'))) . '" /></td>
+			<td><input type="text" required="required" autofocus="autofocus" class="date" name="FromDate" maxlength="10" size="11" value="' . Date($_SESSION['DefaultDateFormat'], Mktime(0,0,0,Date('m'),Date('d')-1,Date('y'))) . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('Enter the date to which orders are to be listed') . ':</td>
-			<td><input type="text" required="required" class="date" alt="' .$_SESSION['DefaultDateFormat'] . '" name="ToDate" maxlength="10" size="10" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
+			<td><input type="text" required="required" class="date" name="ToDate" maxlength="10" size="11" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('Inventory Category') . '</td>

--- a/PDFPeriodStockTransListing.php
+++ b/PDFPeriodStockTransListing.php
@@ -29,11 +29,11 @@ if (!isset($_POST['FromDate'])){
 		<table class="selection">
 		<tr>
 			<td>' . _('Enter the date from which the transactions are to be listed') . ':</td>
-			<td><input type="text" required="required" autofocus="autofocus" name="FromDate" maxlength="10" size="10" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
+			<td><input type="text" required="required" autofocus="autofocus" name="FromDate" maxlength="10" size="11" class="date" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('Enter the date to which the transactions are to be listed') . ':</td>
-			<td><input type="text" required="required" name="ToDate" maxlength="10" size="10" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
+			<td><input type="text" required="required" name="ToDate" maxlength="10" size="11" class="date" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('Transaction type') . '</td>

--- a/PDFPickingList.php
+++ b/PDFPickingList.php
@@ -32,7 +32,7 @@ if ((!isset($_GET['TransNo']) or $_GET['TransNo']=='') and !isset($_POST['TransD
 		<table class="selection">
 		<tr>
 			<td>' . _('Create picking lists for all deliveries to be made on').' : ' . '</td>
-			<td><input type="text" required="required" autofocus="autofocus" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="TransDate" maxlength="10" size="11" value="' . date($_SESSION['DefaultDateFormat'], mktime(date('m'),date('Y'),date('d')+1)) . '" /></td>
+			<td><input type="text" required="required" autofocus="autofocus" class="date" name="TransDate" maxlength="10" size="11" value="' . date($_SESSION['DefaultDateFormat'], mktime(date('m'),date('Y'),date('d')+1)) . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('From Warehouse').' : ' . '</td>

--- a/PDFPriceList.php
+++ b/PDFPriceList.php
@@ -342,7 +342,7 @@ If (isset($_POST['PrintPDF'])) {
 		</tr>
 		<tr>
 			<td>' . _('Effective As At') . ':</td>
-			<td><input type="text" required="required" size="11" class="date"	alt="' . $_SESSION['DefaultDateFormat'] . '" name="EffectiveDate" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
+			<td><input type="text" required="required" maxlength="10" size="11" class="date" name="EffectiveDate" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
 		</tr>
 		</table>
 		<br />

--- a/PDFPrintLabel.php
+++ b/PDFPrintLabel.php
@@ -209,9 +209,9 @@ if (isset($_POST['PrintLabels']) AND $NoOfLabels>0) {
 					}
 					if ($Field['FieldValue'] == 'price'){ //need to format for the number of decimal places
 						$LeftOvers = $pdf->addTextWrap($XPos+$Field['HPos'],$YPos-$LabelDimensions['label_height']+$Field['VPos'],$LabelDimensions['label_width']-$Field['HPos'],$Field['FontSize'],$Value);
-					}elseif ($Field['FieldValue'] == 'logo'){ 
+					}elseif ($Field['FieldValue'] == 'logo'){
 						$pdf->addJpegFromFile($_SESSION['LogoFile'],$XPos+$Field['HPos'],$YPos-$LabelDimensions['label_height']+$Field['VPos'],'', $Field['FontSize']);
-					
+
 					}elseif($Field['Barcode']==1) {
 
 						$BarcodeImage = new code128(str_replace('_','',$Value));
@@ -333,7 +333,7 @@ if (isset($_POST['PrintLabels']) AND $NoOfLabels>0) {
 		</tr>
 		<tr>
 			<td>' . _('Effective As At') . ':</td>
-			<td><input type="text" size="11" class="date"	alt="' . $_SESSION['DefaultDateFormat'] . '" name="EffectiveDate" value="' . Date($_SESSION['DefaultDateFormat']) . '" />';
+			<td><input type="text" maxlength="10" size="11" class="date" name="EffectiveDate" value="' . Date($_SESSION['DefaultDateFormat']) . '" />';
         echo '</td></tr>';
 
 		echo'<tr><td>' . _('Number of labels per item') . ':</td>

--- a/PDFRemittanceAdvice.php
+++ b/PDFRemittanceAdvice.php
@@ -165,7 +165,7 @@ If ((isset($_POST['PrintPDF']))
 
 	echo '<tr>
 			<td>' . _('Date Of Payment') . ':</td>
-			<td><input type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="PaymentDate" maxlength="11" size="12" value="' . $DefaultDate . '" /></td>
+			<td><input type="text" class="date" name="PaymentDate" maxlength="10" size="11" value="' . $DefaultDate . '" /></td>
 		</tr>';
 
 	echo '</table>

--- a/PDFSellThroughSupportClaim.php
+++ b/PDFSellThroughSupportClaim.php
@@ -173,11 +173,11 @@ if (isset($_POST['PrintPDF'])) {
 				<table class="selection">
 					<tr>
 						<td>' . _('Sales Made From') . ' (' . _('in the format') . ' ' . $_SESSION['DefaultDateFormat'] . '):</td>
-						<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="FromDate" size="10" maxlength="10" value="' . $_POST['FromDate'] . '" /></td>
+						<td><input type="text" class="date" name="FromDate" size="11" maxlength="10" value="' . $_POST['FromDate'] . '" /></td>
 					</tr>
 					<tr>
 						<td>' . _('Sales Made To') . ' (' . _('in the format') . ' ' . $_SESSION['DefaultDateFormat'] . '):</td>
-						<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" size="10" maxlength="10" value="' . $_POST['ToDate'] . '" /></td>
+						<td><input type="text" class="date" name="ToDate" size="11" maxlength="10" value="' . $_POST['ToDate'] . '" /></td>
 					</tr>
 				</table>
 				<br />

--- a/PDFSuppTransListing.php
+++ b/PDFSuppTransListing.php
@@ -29,7 +29,7 @@ if (!isset($_POST['Date'])){
 	 echo '<table class="selection">
 	        <tr>
 				<td>' . _('Enter the date for which the transactions are to be listed') . ':</td>
-				<td><input type="text" name="Date" maxlength="10" size="10" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
+				<td><input type="text" name="Date" maxlength="10" size="11" class="date" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>
 			</tr>';
 
 	echo '<tr>

--- a/POReport.php
+++ b/POReport.php
@@ -1515,8 +1515,8 @@ function display()  //####DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_#####
 		</tr>
 		<tr>
 			<td>' . _('Date Range') . ':</td>
-			<td><input type="text" required="required" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="FromDate" size="10" maxlength="10" value="' . $_POST['FromDate'] .'" /> ' . _('To') . ':&nbsp;&nbsp;
-        <input type="text" required="required" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" size="10" maxlength="10" value="' . $_POST['ToDate'] . '" /></td>
+			<td><input type="text" required="required" class="date" name="FromDate" size="11" maxlength="10" value="' . $_POST['FromDate'] .'" /> ' . _('To') . ':&nbsp;&nbsp;
+        <input type="text" required="required" class="date" name="ToDate" size="11" maxlength="10" value="' . $_POST['ToDate'] . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('Part Number') . ':</td>

--- a/Payments.php
+++ b/Payments.php
@@ -995,7 +995,7 @@ if(DB_num_rows($AccountsResults)==0) {
 
 echo '<tr>
 		<td>', _('Date'), ':</td>
-		<td><input alt="', $_SESSION['DefaultDateFormat'], '" class="date" maxlength="10" name="DatePaid" onchange="isDate(this, this.value, ', "'", $_SESSION['DefaultDateFormat'], "'", ')" required="required" size="10" type="text" value="', $_SESSION['PaymentDetail'.$identifier]->DatePaid, '" /></td>
+		<td><input class="date" maxlength="10" name="DatePaid" onchange="isDate(this, this.value, ', "'", $_SESSION['DefaultDateFormat'], "'", ')" required="required" size="11" type="text" value="', $_SESSION['PaymentDetail'.$identifier]->DatePaid, '" /></td>
 	</tr>';
 
 // Currency of payment:

--- a/PcAssignCashTabToTab.php
+++ b/PcAssignCashTabToTab.php
@@ -420,7 +420,7 @@ if (isset($_POST['Process']) OR isset($SelectedTabs)) {
 				</tr>';
 		echo '<tr>
 				<td>' . _('Cash Assignment Date') . ':</td>
-				<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="Date" required="required" autofocus="autofocus" size="10" maxlength="10" value="' . $_POST['Date'] . '" /></td>
+				<td><input type="text" class="date" name="Date" required="required" autofocus="autofocus" size="11" maxlength="10" value="' . $_POST['Date'] . '" /></td>
 			</tr>';
 
 
@@ -432,7 +432,7 @@ if (isset($_POST['Process']) OR isset($SelectedTabs)) {
 				<td>' . _('Amount') . ':</td>
 				<td><input type="text" class="number" name="Amount" size="12" maxlength="11" value="' . locale_number_format($_POST['Amount'],$CurrDecimalPlaces) . '" /></td>
 			</tr>';
-		
+
 		if (!isset($_POST['Notes'])) {
 			$_POST['Notes'] = '';
 		}

--- a/PcAssignCashToTab.php
+++ b/PcAssignCashToTab.php
@@ -379,7 +379,7 @@ if (isset($_POST['Process']) or isset($SelectedTabs)) {
 		echo '<tr>
 				<td>', _('Cash Assignment Date'), ':</td>';
 		echo '<td>
-				<input type="text" class="date" alt="', $_SESSION['DefaultDateFormat'], '" name="Date" size="10" required="required" maxlength="10" value="', $_POST['Date'], '" />
+				<input type="text" class="date" name="Date" size="11" required="required" maxlength="10" value="', $_POST['Date'], '" />
 			</td>
 		</tr>';
 		if (!isset($_POST['Amount'])) {

--- a/PcClaimExpensesFromTab.php
+++ b/PcClaimExpensesFromTab.php
@@ -156,7 +156,7 @@ if (isset($_POST['submit'])) {
 													extension='" . $ReceiptExt . "',
 													size=" . $UploadSize . "
 												WHERE pccashdetail='" . $SelectedIndex . "'";
-					$ReceiptResult = DB_query($ReceiptSQL);					
+					$ReceiptResult = DB_query($ReceiptSQL);
 				} else { //If expenses record does not already have an uploaded receipt
 					if (!file_exists($ReceiptDir)) { //Create the receipts directory if it doesn't already exist
 					mkdir($ReceiptDir, 0775, true);
@@ -622,7 +622,7 @@ if (!isset($SelectedTabs)) {
 		echo '<tr>
 				<td>', _('Date of Expense'), ':</td>
 				<td>
-					<input type="text" class="date" alt="', $_SESSION['DefaultDateFormat'], '" name="Date" size="10" required="required" maxlength="10" value="', $_POST['Date'], '" />
+					<input type="text" class="date" name="Date" size="11" required="required" maxlength="10" value="', $_POST['Date'], '" />
 				</td>
 			</tr>
 			<tr>
@@ -758,7 +758,7 @@ if (!isset($SelectedTabs)) {
 				<input type="file" name="Receipt" id="Receipt" accept="' . implode(',', $ReceiptSupportedExtDotPrefix) . '" title="', _('Accepted file types'), ': ', implode(', ', $ReceiptSupportedExt), '" />
 				</td>
 			</tr>';
-			
+
 		if (!isset($_POST['Purpose'])) {
 			$_POST['Purpose'] = '';
 		}

--- a/PcReportExpense.php
+++ b/PcReportExpense.php
@@ -67,11 +67,11 @@ if ((! isset($_POST['FromDate']) AND ! isset($_POST['ToDate'])) OR isset($_POST[
 		</tr>
 		<tr>
 			<td>' . _('From Date') . ':' . '</td>
-			<td><input tabindex="2" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" type="text" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
+			<td><input tabindex="2" class="date" type="text" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('To Date') . ':' . '</td>
-			<td><input tabindex="3" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" type="text" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
+			<td><input tabindex="3" class="date" type="text" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
 		</tr>
 		</table>
 		<br />
@@ -199,7 +199,7 @@ if ((! isset($_POST['FromDate']) AND ! isset($_POST['ToDate'])) OR isset($_POST[
 		} else {
 			$ReceiptText = _('No attachment');
 		}
-				
+
 		if ($MyRow['authorized'] == '0000-00-00') {
 			$AuthorisedDate = _('Unauthorised');
 		} else {

--- a/PcReportTab.php
+++ b/PcReportTab.php
@@ -62,11 +62,11 @@ if ((! isset($_POST['FromDate']) AND ! isset($_POST['ToDate'])) OR isset($_POST[
 		</tr>
 		<tr>
 			<td>' . _('From Date :') . '</td>
-			<td><input tabindex="2" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" type="text" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
+			<td><input tabindex="2" class="date" type="text" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('To Date:')  . '</td>
-			<td><input tabindex="3" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" type="text" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
+			<td><input tabindex="3" class="date" type="text" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
 		</tr>
 		</table>
 		<br />
@@ -263,7 +263,7 @@ if ((! isset($_POST['FromDate']) AND ! isset($_POST['ToDate'])) OR isset($_POST[
 				$TaxesDescription .= $MyTaxRow['description'] . "\n"; //Line breaks not working !?
 				$TaxesTaxAmount .= locale_number_format($MyTaxRow['amount'], $CurrDecimalPlaces) . "\n"; //Line breaks not working !?
 		}
-		
+
 		if ($MyRow['authorized'] == '0000-00-00') {
 					$AuthorisedDate = _('Unauthorised');
 				} else {

--- a/PcTabExpensesList.php
+++ b/PcTabExpensesList.php
@@ -275,7 +275,7 @@ function display()  //####DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_#####
 	echo '<p class="page_title_text">
 			<img src="' . $RootPath . '/css/' . $_SESSION['Theme'] . '/images/magnifier.png" title="' . _('Excel file for Petty Cash Tab Expenses List') . '" alt="" />' . ' ' . _('Excel file for Petty Cash Tab Expenses List') . '
 		</p>';
-		
+
 	# Sets default date range for current month
 	if (!isset($_POST['FromDate'])){
 		$_POST['FromDate'] = Date($_SESSION['DefaultDateFormat'], mktime(0,0,0,Date('m'),1,Date('Y')));
@@ -303,8 +303,8 @@ function display()  //####DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_#####
 
 	echo '<tr>
 			<td>' . _('Date Range') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="FromDate" size="10" maxlength="10" value="' . $_POST['FromDate'] . '" />
-			' . _('To') . ':<input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" size="10" maxlength="10" value="' . $_POST['ToDate'] . '" /></td>
+			<td><input type="text" class="date" name="FromDate" size="11" maxlength="10" value="' . $_POST['FromDate'] . '" />
+			' . _('To') . ':<input type="text" class="date" name="ToDate" size="11" maxlength="10" value="' . $_POST['ToDate'] . '" /></td>
 		</tr>';
 
 	echo '

--- a/PriceMatrix.php
+++ b/PriceMatrix.php
@@ -1,6 +1,6 @@
 <?php
 
-//The scripts used to provide a Price break matrix for those users who like selling product in quantity break at different constant price. 
+//The scripts used to provide a Price break matrix for those users who like selling product in quantity break at different constant price.
 
 include('includes/session.php');
 $Title = _('Price break matrix Maintenance');
@@ -47,7 +47,7 @@ if (isset($_POST['submit'])) {
 			prnMsg(_('The end date is expected to be after the start date, enter an end date after the start date for this price'),'error');
 		}
 	}
-	
+
 
 	if(Is_Date($_POST['EndDate'])){
 		$SQLEndDate = FormatDateForSQL($_POST['EndDate']);
@@ -73,7 +73,7 @@ if (isset($_POST['submit'])) {
 	if (isset($_POST['OldTypeAbbrev']) AND isset($_POST['OldCurrAbrev']) AND mb_strlen($StockID)>1 AND $InputError !=1){
 
 		/* Update existing prices */
-		$sql = "UPDATE pricematrix SET 
+		$sql = "UPDATE pricematrix SET
 					salestype='" . $_POST['SalesType'] . "',
 					currabrev='" . $_POST['CurrAbrev'] . "',
 					price='" . filter_number_format($_POST['Price']) . "',
@@ -124,7 +124,7 @@ if (isset($_POST['submit'])) {
 		unset($_POST['StartDate']);
 		unset($_POST['EndDate']);
 		unset($SQLEndDate);
-		unset($SQLStartDate); 
+		unset($SQLStartDate);
 	}
 } elseif (isset($_GET['Delete']) and $_GET['Delete']=='yes') {
 /*the link to delete a selected record was clicked instead of the submit button */
@@ -158,7 +158,7 @@ if (isset($_GET['Edit'])){
 	$_POST['StartDate'] = ConvertSQLDate($_GET['StartDate']);
 	$_POST['EndDate'] = ConvertSQLDate($_GET['EndDate']);
        	$_POST['QuantityBreak'] = $_GET['QuantityBreak'];
-}	
+}
 $SQL = "SELECT currabrev FROM currencies";
 $result = DB_query($SQL);
 require_once('includes/CurrenciesArray.php');
@@ -217,9 +217,9 @@ if (!isset($_POST['Price'])) {
 	$_POST['Price'] = 0;
 }
 echo '<tr><td>'. _('Price Effective From Date') . ':</td>
-	<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="StartDate" required="required" size="10" maxlength="10" title="' . _('Enter the date from which this price should take effect.') . '" value="' . $_POST['StartDate'] . '" /></td></tr>';
+	<td><input type="text" class="date" name="StartDate" required="required" size="11" maxlength="10" title="' . _('Enter the date from which this price should take effect.') . '" value="' . $_POST['StartDate'] . '" /></td></tr>';
 echo '<tr><td>' . _('Price Effective To Date') . ':</td>
-			<td><input type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="EndDate" size="10" maxlength="10" title="' . _('Enter the date to which this price should be in effect to, or leave empty if the price should continue indefinitely') . '" value="' . $_POST['EndDate'] . '" />';
+			<td><input type="text" class="date" name="EndDate" size="11" maxlength="10" title="' . _('Enter the date to which this price should be in effect to, or leave empty if the price should continue indefinitely') . '" value="' . $_POST['EndDate'] . '" />';
 
 
 echo '<tr>
@@ -252,7 +252,7 @@ $sql = "SELECT sales_type,
 		INNER JOIN currencies
 		ON pricematrix.currabrev=currencies.currabrev
 		WHERE pricematrix.stockid='" . $StockID . "'
-		ORDER BY pricematrix.currabrev, 
+		ORDER BY pricematrix.currabrev,
 			salestype,
 			stockid,
 			quantitybreak";
@@ -377,7 +377,7 @@ function ReSequenceEffectiveDates ($Item, $PriceList, $CurrAbbrev, $QuantityBrea
 			$Price = $myrow['price'];
 		} // end of loop around all prices
 
-		
+
 
 } // end function ReSequenceEffectiveDates
 

--- a/PricesBasedOnMarkUp.php
+++ b/PricesBasedOnMarkUp.php
@@ -150,11 +150,11 @@ echo '<tr>
 
 echo '<tr>
 		<td>' . _('New Price To Be Effective From') . ':</td>
-		<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="PriceStartDate" size="10" maxlength="10" value="' . $_POST['PriceStartDate'] . '" /></td></tr>';
+		<td><input type="text" class="date" name="PriceStartDate" size="11" maxlength="10" value="' . $_POST['PriceStartDate'] . '" /></td></tr>';
 
 echo '<tr>
 		<td>' . _('New Price To Be Effective To (Blank = No End Date)') . ':</td>
-		<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="PriceEndDate" size="10" maxlength="10" value="' . $_POST['PriceEndDate'] . '" /></td></tr>';
+		<td><input type="text" class="date" name="PriceEndDate" size="11" maxlength="10" value="' . $_POST['PriceEndDate'] . '" /></td></tr>';
 
 if (!isset($_POST['IncreasePercent'])){
 	$_POST['IncreasePercent']=0;

--- a/Prices_Customer.php
+++ b/Prices_Customer.php
@@ -352,11 +352,11 @@ while ($myrow=DB_fetch_array($result)) {
 echo '</select></td></tr>';
 echo '<tr>
 		<td>' . _('Start Date') . ':</td>
-		<td><input type="text" name="StartDate" class="date" alt="'.$_SESSION['DefaultDateFormat']. '" size="11" maxlength="10" value="' . $_POST['StartDate'] . '" /></td>
+		<td><input type="text" name="StartDate" class="date" size="11" maxlength="10" value="' . $_POST['StartDate'] . '" /></td>
 	</tr>';
 echo '<tr>
 		<td>' . _('End Date') . ':</td>
-		<td><input type="text" name="EndDate" class="date" alt="'.$_SESSION['DefaultDateFormat']. '" size="11" maxlength="10" value="' . $_POST['EndDate'] . '" /></td></tr>';
+		<td><input type="text" name="EndDate" class="date" size="11" maxlength="10" value="' . $_POST['EndDate'] . '" /></td></tr>';
 
 echo '<tr><td>' . _('Price') . ':</td>
           <td><input type="text" class="number" name="Price" size="11" maxlength="10" value="' . locale_number_format($_POST['Price'],2) . '" /></td>

--- a/PurchasesReport.php
+++ b/PurchasesReport.php
@@ -249,7 +249,7 @@ if(isset($_POST['PeriodFrom']) AND isset($_POST['PeriodTo']) AND $_POST['Action'
 	if(!isset($_POST['PeriodFrom'])) {
 		$_POST['PeriodFrom'] = date($_SESSION['DefaultDateFormat'], strtotime("-1 year", time()));// One year before current date.
 	}
-	echo 		'<td><input alt="', $_SESSION['DefaultDateFormat'], '" class="date" id="PeriodFrom" maxlength="10" minlength="0" name="PeriodFrom" required="required" size="12" type="text" value="', $_POST['PeriodFrom'], '" />',
+	echo 		'<td><input class="date" id="PeriodFrom" maxlength="10" name="PeriodFrom" required="required" size="11" type="text" value="', $_POST['PeriodFrom'], '" />',
 					(!isset($_SESSION['ShowFieldHelp']) || $_SESSION['ShowFieldHelp'] ? _('Select the beginning of the reporting period') : ''), // If it is not set the $_SESSION['ShowFieldHelp'] parameter OR it is TRUE, shows the page help text.
 		 		'</td>
 			</tr>',
@@ -259,7 +259,7 @@ if(isset($_POST['PeriodFrom']) AND isset($_POST['PeriodTo']) AND $_POST['Action'
 	if(!isset($_POST['PeriodTo'])) {
 		$_POST['PeriodTo'] = date($_SESSION['DefaultDateFormat']);
 	}
-	echo 		'<td><input alt="', $_SESSION['DefaultDateFormat'], '" class="date" id="PeriodTo" maxlength="10" minlength="0" name="PeriodTo" required="required" size="12" type="text" value="', $_POST['PeriodTo'], '" />',
+	echo 		'<td><input class="date" id="PeriodTo" maxlength="10" name="PeriodTo" required="required" size="11" type="text" value="', $_POST['PeriodTo'], '" />',
 					(!isset($_SESSION['ShowFieldHelp']) || $_SESSION['ShowFieldHelp'] ? _('Select the end of the reporting period') : ''), // If it is not set the $_SESSION['ShowFieldHelp'] parameter OR it is TRUE, shows the page help text.
 		 		'</td>
 			</tr>',

--- a/RecurringSalesOrders.php
+++ b/RecurringSalesOrders.php
@@ -417,7 +417,7 @@ if (!isset($_POST['StartDate'])){
 if ($NewRecurringOrder=='Yes'){
 	echo '<tr>
 	<td>' .  _('Start Date') .':</td>
-	<td><input type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="StartDate" size="11" maxlength="10" value="' . $_POST['StartDate'] .'" /></td></tr>';
+	<td><input type="text" class="date" name="StartDate" size="11" maxlength="10" value="' . $_POST['StartDate'] .'" /></td></tr>';
 } else {
 	echo '<tr>
 	<td>' .  _('Last Recurrence') . ':</td>
@@ -431,7 +431,7 @@ if (!isset($_POST['StopDate'])){
 
 echo '<tr>
 	<td>' .  _('Finish Date') .':</td>
-	<td><input type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="StopDate" size="11" maxlength="10" value="' . $_POST['StopDate'] .'" /></td></tr>';
+	<td><input type="text" class="date" name="StopDate" size="11" maxlength="10" value="' . $_POST['StopDate'] .'" /></td></tr>';
 
 echo '<tr>
 	<td>' .  _('Frequency of Recurrence') .':</td>

--- a/ReverseGRN.php
+++ b/ReverseGRN.php
@@ -357,7 +357,7 @@ if (isset($_GET['GRNNo']) AND isset($_POST['SupplierID'])){
     echo '<input type="hidden" name="SuppName" value="' . $_POST['SuppName'] . '" />';
 	echo '<table class="selection"><tr>';
 	echo '<td>' . _('Show all goods received after') . ': </td>
-			<td><input type="text" class="date" alt="'. $_SESSION['DefaultDateFormat'].'" name="RecdAfterDate" value="' . $_POST['RecdAfterDate'] . '" maxlength="10" size="10" /></td>
+			<td><input type="text" class="date" name="RecdAfterDate" value="' . $_POST['RecdAfterDate'] . '" maxlength="10" size="11" /></td>
 		</tr>
 		</table>
 		<br />

--- a/SalesByTypePeriodInquiry.php
+++ b/SalesByTypePeriodInquiry.php
@@ -67,11 +67,11 @@ if ($_POST['DateRange']=='Custom'){
 	}
 	echo '<tr>
 			<td>' . _('Date From') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
+			<td><input type="text" class="date" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
 			</tr>';
 	echo '<tr>
 			<td>' . _('Date To') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
+			<td><input type="text" class="date" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
 			</tr>';
 }
 echo '</table>

--- a/SalesCategoryPeriodInquiry.php
+++ b/SalesCategoryPeriodInquiry.php
@@ -61,11 +61,11 @@ if ($_POST['DateRange']=='Custom'){
 	}
 	echo '<tr>
 			<td>' . _('Date From') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
+			<td><input type="text" class="date" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
 			</tr>';
 	echo '<tr>
 			<td>' . _('Date To') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
+			<td><input type="text" class="date" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
 			</tr>';
 }
 echo '</table>';

--- a/SalesInquiry.php
+++ b/SalesInquiry.php
@@ -1102,9 +1102,9 @@ function display()  //####DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_#####
 
 	echo '<tr>
 			<td>' . _('Date Range') . ':</td>
-			<td><input type="text" class="date" alt="' .$_SESSION['DefaultDateFormat'] .'" name="FromDate" size="10" maxlength="10" value="' . $_POST['FromDate'] . '" /></td>
+			<td><input type="text" class="date" name="FromDate" size="11" maxlength="10" value="' . $_POST['FromDate'] . '" /></td>
 			<td>' . _('To') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" size="10" maxlength="10" value="' . $_POST['ToDate'] . '" /></td>
+			<td><input type="text" class="date" name="ToDate" size="11" maxlength="10" value="' . $_POST['ToDate'] . '" /></td>
 		</tr>';
 	if(!isset($_POST['PartNumber'])) {
 		$_POST['PartNumber']='';

--- a/SalesTopCustomersInquiry.php
+++ b/SalesTopCustomersInquiry.php
@@ -63,11 +63,11 @@ if ($_POST['DateRange']=='Custom'){
 	}
 	echo '<tr>
 			<td>' . _('Date From') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
+			<td><input type="text" class="date" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
 			</tr>';
 	echo '<tr>
 			<td>' . _('Date To') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
+			<td><input type="text" class="date" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
 			</tr>';
 }
 echo '</table></td>

--- a/SalesTopItemsInquiry.php
+++ b/SalesTopItemsInquiry.php
@@ -64,11 +64,11 @@ if ($_POST['DateRange']=='Custom'){
 	}
 	echo '<tr>
 			<td>' . _('Date From') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
+			<td><input type="text" class="date" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
 			</tr>';
 	echo '<tr>
 			<td>' . _('Date To') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
+			<td><input type="text" class="date" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
 			</tr>';
 }
 echo '</table></td>

--- a/SelectCompletedOrder.php
+++ b/SelectCompletedOrder.php
@@ -443,7 +443,7 @@ if (!isset($_POST['OrderNumber'])){
 echo '<td>' . _('Order Number') . ':</td>
 	<td><input type="text" name="OrderNumber" maxlength="8" size="9" value ="' . $_POST['OrderNumber'] . '" /></td>
 	<td>' . _('for all orders placed after') . ': </td>
-	<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] .'"  name="OrdersAfterDate" maxlength="10" size="11" value="' . $_POST['OrdersAfterDate'] . '" /></td>
+	<td><input type="text" class="date" name="OrdersAfterDate" maxlength="10" size="11" value="' . $_POST['OrdersAfterDate'] . '" /></td>
 	<td><input type="submit" name="SearchOrders" value="' . _('Search Orders') . '" /></td>
 	</tr>';
 echo '<tr>

--- a/SellThroughSupport.php
+++ b/SellThroughSupport.php
@@ -449,11 +449,11 @@ if (isset($SupplierID)) { //not selecting a supplier
 		</tr>
 		<tr>
 			<td>' . _('Support Start Date') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="EffectiveFrom" maxlength="10" size="11" value="' . $_POST['EffectiveFrom'] . '" /></td>
+			<td><input type="text" class="date" name="EffectiveFrom" maxlength="10" size="11" value="' . $_POST['EffectiveFrom'] . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('Support End Date') . ':</td>
-			<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="EffectiveTo" maxlength="10" size="11" value="' . $_POST['EffectiveTo'] . '" /></td>
+			<td><input type="text" class="date" name="EffectiveTo" maxlength="10" size="11" value="' . $_POST['EffectiveTo'] . '" /></td>
 		</tr>
 		</table>
 		<br />

--- a/Shipments.php
+++ b/Shipments.php
@@ -320,9 +320,9 @@ if (isset($_SESSION['Shipment']->ETA)){
 
 echo '<tr><td>' .  _('Expected Arrival Date (ETA)'). ': </td>';
 if (isset($_SESSION['Shipment']->ETA)) {
-	echo '<td><input type="text" name="ETA" class="date" alt="'.$_SESSION['DefaultDateFormat'].'"  maxlength="10" size="10" value="' . $ETA . '" /></td>';
+	echo '<td><input type="text" name="ETA" class="date"  maxlength="10" size="11" value="' . $ETA . '" /></td>';
 } else {
-	echo '<td><input type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="ETA" maxlength="10" size="10" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>';
+	echo '<td><input type="text" class="date" name="ETA" maxlength="10" size="11" value="' . Date($_SESSION['DefaultDateFormat']) . '" /></td>';
 }
 echo '<td>' .  _('Into').' ';
 

--- a/SpecialOrder.php
+++ b/SpecialOrder.php
@@ -726,7 +726,7 @@ $_POST['ReqDelDate'] = Date($_SESSION['DefaultDateFormat'],Mktime(0,0,0,Date('m'
 
 echo '<tr>
 		<td>' . _('Required Delivery Date') . ':</td>
-		<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" size="12" maxlength="11" name="ReqDelDate" value="' . $_POST['ReqDelDate'] . '" /></td>
+		<td><input type="text" class="date" size="11" maxlength="10" name="ReqDelDate" value="' . $_POST['ReqDelDate'] . '" /></td>
 	</tr>';
 
 echo '</table>'; /* end of main table */

--- a/StockCategorySalesInquiry.php
+++ b/StockCategorySalesInquiry.php
@@ -55,11 +55,11 @@ if (!isset($_POST['FromDate'])){
 }
 echo '<tr>
 		<td>' . _('Date From') . ':</td>
-		<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
+		<td><input type="text" class="date" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
 		</tr>';
 echo '<tr>
 		<td>' . _('Date To') . ':</td>
-		<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
+		<td><input type="text" class="date" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
 	</tr>
 </table>
 <br />

--- a/StockLocMovements.php
+++ b/StockLocMovements.php
@@ -56,8 +56,8 @@ if (!isset($_POST['BeforeDate']) or !Is_date($_POST['BeforeDate'])) {
 if (!isset($_POST['AfterDate']) or !Is_date($_POST['AfterDate'])) {
 	$_POST['AfterDate'] = Date($_SESSION['DefaultDateFormat'], Mktime(0, 0, 0, Date('m') - 1, Date('d'), Date('y')));
 }
-echo ' ', _('Show Movements before'), ': <input type="text" class="date" alt="', $_SESSION['DefaultDateFormat'], '" name="BeforeDate" size="12" required="required" maxlength="12" value="', $_POST['BeforeDate'], '" />',
-	' ', _('But after'), ': <input type="text" class="date" alt="', $_SESSION['DefaultDateFormat'], '" name="AfterDate" size="12" required="required" maxlength="12" value="', $_POST['AfterDate'], '" />',
+echo ' ', _('Show Movements before'), ': <input type="text" class="date" name="BeforeDate" size="11" required="required" maxlength="10" value="', $_POST['BeforeDate'], '" />',
+	' ', _('But after'), ': <input type="text" class="date" name="AfterDate" size="11" required="required" maxlength="10" value="', $_POST['AfterDate'], '" />',
 	'</td>
 	 </tr>
 	 </table>

--- a/StockMovements.php
+++ b/StockMovements.php
@@ -77,8 +77,8 @@ echo '</select></th>
 	</tr>';
 echo '<tr>
 		<th colspan="12">', _('Show Movements between'), ':
-			<input type="text" name="AfterDate" class="date" alt="', $_SESSION['DefaultDateFormat'], '" size="12" required="required" maxlength="12" value="', $_POST['AfterDate'], '" /> ' . _('and') . ':
-			<input type="text" name="BeforeDate" class="date" alt="', $_SESSION['DefaultDateFormat'], '" size="12" required="required" maxlength="12" value="', $_POST['BeforeDate'], '" />
+			<input type="text" name="AfterDate" class="date" size="11" required="required" maxlength="10" value="', $_POST['AfterDate'], '" /> ' . _('and') . ':
+			<input type="text" name="BeforeDate" class="date" size="11" required="required" maxlength="10" value="', $_POST['BeforeDate'], '" />
 			<input type="submit" name="ShowMoves" value="', _('Show Stock Movements'), '" />
 		</th>
 	</tr>';

--- a/StockQuantityByDate.php
+++ b/StockQuantityByDate.php
@@ -64,7 +64,7 @@ if (!isset($_POST['OnHandDate'])){
 }
 
 echo '<td>' . _('On-Hand On Date') . ':</td>
-	<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="OnHandDate" size="12" maxlength="12" value="' . $_POST['OnHandDate'] . '" /></td></tr>';
+	<td><input type="text" class="date" name="OnHandDate" size="11" maxlength="10" value="' . $_POST['OnHandDate'] . '" /></td></tr>';
 echo '<tr>
 		<td colspan="6">
 		<div class="centre">

--- a/SuppPaymentRun.php
+++ b/SuppPaymentRun.php
@@ -305,7 +305,7 @@ if ((isset($_POST['PrintPDF']) OR isset($_POST['PrintPDFAndProcess']))
 
 	echo '<tr>
 			<td>' . _('Payments Due To') . ':</td>
-            <td><input type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="AmountsDueBy" maxlength="11" size="12" value="' . $DefaultDate . '" /></td>
+            <td><input type="text" class="date" name="AmountsDueBy" maxlength="10" size="11" value="' . $DefaultDate . '" /></td>
           </tr>';
 
 	$SQL = "SELECT bankaccountname, accountcode FROM bankaccounts";

--- a/SupplierCredit.php
+++ b/SupplierCredit.php
@@ -283,7 +283,7 @@ if (!isset($_SESSION['SuppTrans']->TranDate)){
 	$_SESSION['SuppTrans']->TranDate= Date($_SESSION['DefaultDateFormat'], Mktime(0,0,0,Date('m'),Date('d')-1,Date('y')));
 }
 echo '<td style="color:red">' . _('Credit Note Date') . ' (' . _('in format') . ' ' . $_SESSION['DefaultDateFormat'] . ') :</td>
-		<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" size="11" maxlength="10" name="TranDate" value="' . $_SESSION['SuppTrans']->TranDate . '" /></td>
+		<td><input type="text" class="date" size="11" maxlength="10" name="TranDate" value="' . $_SESSION['SuppTrans']->TranDate . '" /></td>
 		<td style="color:red">' . _('Exchange Rate') . ':</td>
 		<td><input type="text" class="number" size="11" maxlength="10" name="ExRate" value="' . locale_number_format($_SESSION['SuppTrans']->ExRate,'Variable') . '" /></td>
 	</tr>

--- a/SupplierInvoice.php
+++ b/SupplierInvoice.php
@@ -636,7 +636,7 @@ if (!isset($_POST['PostInvoice'])){
 		$_SESSION['SuppTrans']->TranDate= Date($_SESSION['DefaultDateFormat'], Mktime(0,0,0,Date('m'),Date('d')-1,Date('y')));
 	}
 	echo '<td>' . _('Invoice Date') . ' (' . _('in format') . ' ' . $_SESSION['DefaultDateFormat'] . ') :</td>
-		<td><input type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" size="11" maxlength="10" name="TranDate" value="' . $_SESSION['SuppTrans']->TranDate . '" /></td>
+		<td><input type="text" class="date" size="11" maxlength="10" name="TranDate" value="' . $_SESSION['SuppTrans']->TranDate . '" /></td>
 		<td>' . _('Exchange Rate') . ':</td>
 		<td><input class="number" maxlength="12" name="ExRate" size="14" type="text" value="' . locale_number_format($_SESSION['SuppTrans']->ExRate,10) . '" /></td>
 	</tr>

--- a/SupplierTenders.php
+++ b/SupplierTenders.php
@@ -345,7 +345,7 @@ if (isset($_POST['TenderType']) and $_POST['TenderType']!=3 and isset($_SESSION[
 					<td>' . $LineItems->Units . '</td>
 					<td><input type="text" class="number" required="true" name="Price'.$LineItems->LineNo.'" value="'.locale_number_format($LineItems->Price,2,'.','').'" /></td>
 					<td class="number">' . locale_number_format($LineItems->Price*$LineItems->Quantity,2) . '</td>
-					<td><input type="text" size="11" class="date" required="true" alt="'.$_SESSION['DefaultDateFormat'].'" name="expirydate'.$LineItems->LineNo.'" value="'.$LineItems->ExpiryDate.'" /></td>
+					<td><input type="text" maxlength="10" size="11" class="date" required="true" name="expirydate'.$LineItems->LineNo.'" value="'.$LineItems->ExpiryDate.'" /></td>
 					<td><a href="' . htmlspecialchars($_SERVER['PHP_SELF'],ENT_QUOTES,'UTF-8') . '?identifier='.$identifier.'&Delete=' . $LineItems->LineNo . '&Type=' . $_POST['TenderType'] . '">' . _('Remove') . '</a></td>
 				</tr>';
 		}
@@ -553,7 +553,7 @@ if (isset($_POST['TenderType'])
 				<td>' . $MyItemRow['suppliersuom'] . '</td>
 				<td>' . $myrow[1] . '</td>
 				<td><input type="text" class="number" title="'._('Input must be in numeric format').'"  size="10" name="Price'. $i . '" value="0.00" /></td>
-				<td><input type="text" class="date" alt="' .$_SESSION['DefaultDateFormat'] .'" name="RequiredByDate'. $i . '" size="11" value="' . ConvertSQLDate($MyItemRow['requiredbydate']) . '" /></td>
+				<td><input type="text" class="date" name="RequiredByDate'. $i . '" maxlength="10" size="11" value="' . ConvertSQLDate($MyItemRow['requiredbydate']) . '" /></td>
 				</tr>';
 			$i++;
 		}

--- a/SupplierTransInquiry.php
+++ b/SupplierTransInquiry.php
@@ -51,9 +51,9 @@ if (!isset($_POST['SupplierNo'])) {
 	$_POST['SupplierNo'] = '';
 }
 echo '<td>' . _('From') . ':</td>
-		<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
+		<td><input type="text" class="date" name="FromDate" maxlength="10" size="11" value="' . $_POST['FromDate'] . '" /></td>
 		<td>' . _('To') . ':</td>
-		<td><input type="text" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
+		<td><input type="text" class="date" name="ToDate" maxlength="10" size="11" value="' . $_POST['ToDate'] . '" /></td>
 		<td>' . _('Supplier No') . ':</td>
 		<td><input type="text" name="SupplierNo" size="11" maxlength="10" value="' . $_POST['SupplierNo'] . '" />
 		</td>

--- a/Suppliers.php
+++ b/Suppliers.php
@@ -753,7 +753,7 @@ if (!isset($SupplierID)) {
 	$DateString = Date($_SESSION['DefaultDateFormat']);
 	echo '<tr>
 			<td>' . _('Supplier Since') . ' (' . $_SESSION['DefaultDateFormat'] . '):</td>
-			<td><input type="text" class="date" alt="' .$_SESSION['DefaultDateFormat'] .'" name="SupplierSince" value="' . $DateString . '" size="12" maxlength="10" /></td>
+			<td><input type="text" class="date" name="SupplierSince" value="' . $DateString . '" size="11" maxlength="10" /></td>
 		</tr>
 		<tr>
 			<td>' . _('Bank Particulars') . ':</td>
@@ -999,7 +999,7 @@ else {
 		</tr>
 		<tr>
 			<td>' . _('Supplier Since') . ' (' . $_SESSION['DefaultDateFormat'] .'):</td>
-			<td><input '.(in_array('SupplierSince',$Errors) ? 'class="inputerror"' : '').' size="12" maxlength="10" type="text" class="date" alt="'.$_SESSION['DefaultDateFormat'].'" name="SupplierSince" value="' . $_POST['SupplierSince'] . '" /></td>
+			<td><input '.(in_array('SupplierSince',$Errors) ? 'class="inputerror"' : '').' size="11" maxlength="10" type="text" class="date" name="SupplierSince" value="' . $_POST['SupplierSince'] . '" /></td>
 		</tr>
 		<tr>
 			<td>' . _('Bank Particulars') . ':</td>

--- a/WorkOrderIssue.php
+++ b/WorkOrderIssue.php
@@ -809,7 +809,7 @@ while($WORow = DB_fetch_array($WOResult)){
 
 echo '<tr>
 		<td class="label">' . _('Date Material Issued') . ':</td>
-		<td><input type="text" name="IssuedDate" value="' . Date($_SESSION['DefaultDateFormat']) . '" class="date" size="10" alt="'.$_SESSION['DefaultDateFormat'].'" /></td>
+		<td><input type="text" name="IssuedDate" value="' . Date($_SESSION['DefaultDateFormat']) . '" class="date" maxlength="10" size="11" /></td>
 		<td class="label">' . _('Issued From') . ':</td>
 		<td>';
 

--- a/WorkOrderReceive.php
+++ b/WorkOrderReceive.php
@@ -850,9 +850,7 @@ echo '<table class="selection">
 		//add expiry date for perishable product
 		if($WORow['perishable']==1){
 			echo '<td>' . _('Expiry Date') . ':<td>
-			      <td><input type="text" name="ExpiryDate" class="date" alt="'.$_SESSION['DefaultDateFormat'].'"
-				         required  />
-			      </td>';
+			      <td><input type="text" maxlength="10" size="11" name="ExpiryDate" class="date" required /></td>';
 		}
 
 		echo '<td>' . _('Received Into') . ':</td>

--- a/Z_ImportPriceList.php
+++ b/Z_ImportPriceList.php
@@ -156,7 +156,7 @@ if (isset($_FILES['PriceListFile']) and $_FILES['PriceListFile']['name']) { //st
 			_('The StockID, SalesType, and CurrencyCode fields must have a corresponding entry in the stockmaster, salestypes, and currencies tables.') . '</div>';
 
 	echo '<br /><input type="hidden" name="MAX_FILE_SIZE" value="1000000" />' .
-			_('Prices effective from') . ':&nbsp;<input type="text" name="StartDate" size="10" class="date" alt="' . $_SESSION['DefaultDateFormat'] . '" value="' . date($_SESSION['DefaultDateFormat']) . '" />&nbsp;' .
+			_('Prices effective from') . ':&nbsp;<input type="text" name="StartDate" maxlength="10" size="11" class="date" value="' . date($_SESSION['DefaultDateFormat']) . '" />&nbsp;' .
 			_('Upload file') . ': <input name="PriceListFile" type="file" />
 			<input type="submit" name="submit" value="' . _('Send File') . '" />
 		</div>

--- a/includes/InputSerialItemsKeyed.php
+++ b/includes/InputSerialItemsKeyed.php
@@ -107,7 +107,7 @@ if ($EditControlled){
 		if ($LineItem->Serialised==1){
 			echo '<input type="hidden" name="Qty' . $StartAddingAt .'" value="1" /></TR>';
 		} else if ($LineItem->Serialised==0 and $Perishable==1) {
-			echo '<td><input type="text" class="number" name="Qty' . $StartAddingAt .'" size="11" value="'. locale_number_format($Bundle->BundleQty, $LineItem->DecimalPlaces). '" maxlength="10" /></td><td><input type="text" name="ExpiryDate' . $StartAddingAt . '" size="11" value="' . $Bundle->ExpiryDate . '" alt="'.$_SESSION['DefaultDateFormat'].'" maxlength="10" /></td></tr>';
+			echo '<td><input type="text" class="number" name="Qty' . $StartAddingAt .'" size="11" value="'. locale_number_format($Bundle->BundleQty, $LineItem->DecimalPlaces). '" maxlength="10" /></td><td><input type="text" name="ExpiryDate' . $StartAddingAt . '" size="11" value="' . $Bundle->ExpiryDate . '" class="date" maxlength="10" /></td></tr>';
 		} else {
 			echo '<td><input type="text" class="number" name="Qty' . $StartAddingAt .'" size="11" value="'. locale_number_format($Bundle->BundleQty, $LineItem->DecimalPlaces). '" maxlength="10" /></tr>';
 		}
@@ -130,12 +130,12 @@ for ($i=0;$i < 10;$i++){
 				</tr>';
 		} else {
 			echo '<td><input type="hidden" name="Qty' . ($StartAddingAt+$i) .'" value="1" />
-					<input type="text" class="date" name="ExpiryDate' . ($StartAddingAt+$i) .'" size="11" value="" alt="'.$_SESSION['DefaultDateFormat'].'"  maxlength="10" /></td>
+					<input type="text" class="date" name="ExpiryDate' . ($StartAddingAt+$i) .'" size="11" value="" maxlength="10" /></td>
 				</tr>';
 		}
 	} else if ($LineItem->Serialised==0 and $Perishable==1) {
 		echo '<td><input type="text" class="number" name="Qty' . ($StartAddingAt+$i) .'" size="11"  maxlength="10" /></td>
-				<td><input type="text" class="date" name="ExpiryDate' . ($StartAddingAt+$i) .'" size="11" value="" alt="'.$_SESSION['DefaultDateFormat'].'"  maxlength="10" /></td>
+				<td><input type="text" class="date" name="ExpiryDate' . ($StartAddingAt+$i) .'" size="11" value="" maxlength="10" /></td>
 			</tr>';
 	} else {
 		echo '<td><input type="text" class="number" name="Qty' . ($StartAddingAt+$i) .'" size="11"  maxlength="10" /></td></tr>';

--- a/includes/OutputSerialItems.php
+++ b/includes/OutputSerialItems.php
@@ -185,7 +185,7 @@ while ($myrow=DB_fetch_array($result)){
 			echo '<td class="number">' . locale_number_format($myrow['quantity'],$LineItem->DecimalPlaces) . '</td>';
 		}
 		echo '<td><input type="text" class="number" name="Qty' . ($StartAddingAt+$RowNumber) .'" size="11" value="0" maxlength="10" /></td>';
-		echo '<td><input type="hidden" class="date" name="ExpiryDate' . ($StartAddingAt+$RowNumber) .'" size="11" value="'.ConvertSQLDate($myrow['expirationdate']).'" alt="'.$_SESSION['DefaultDateFormat'].'"  maxlength="10" />' . ConvertSQLDate($myrow['expirationdate']) . '</td></tr>';
+		echo '<td><input type="hidden" class="date" name="ExpiryDate' . ($StartAddingAt+$RowNumber) .'" size="11" value="'.ConvertSQLDate($myrow['expirationdate']).'" maxlength="10" />' . ConvertSQLDate($myrow['expirationdate']) . '</td></tr>';
 	} else {
 		echo '<td><input type="text" class="number" name="Qty' . ($StartAddingAt+$RowNumber) .'" size=11  value="'. locale_number_format($myrow['quantity'],$LineItem->DecimalPlaces).'"  maxlength="10" /></td></tr>';
 	}


### PR DESCRIPTION
Date format handling is replaced by localStorage.

Also, ensure that the size and maxlength attribute values are consistent with the date fields.